### PR TITLE
[CB-4791] add missing android namespace

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+	xmlns:android="http://schemas.android.com/apk/res/android"
            id="org.apache.cordova.core.vibration"
       version="0.3.0">
 


### PR DESCRIPTION
adds the android namespace which causes problems for uses-permission on config-file
