### PR TITLE
CB-7216 API audit for vibration on wp8

### DIFF
--- a/src/wp/Vibration.cs
+++ b/src/wp/Vibration.cs
@@ -53,5 +53,11 @@ namespace WPCordovaClassLib.Cordova.Commands
             // TODO: may need to add listener to trigger DispatchCommandResult when the vibration ends...
             DispatchCommandResult();
         }
+
+        public void cancelVibration(string options)
+        {
+            VibrateController.Default.Stop();
+            DispatchCommandResult();
+        }
     }
 }

--- a/src/wp/Vibration.cs
+++ b/src/wp/Vibration.cs
@@ -28,8 +28,8 @@ namespace WPCordovaClassLib.Cordova.Commands
 {
     public class Vibration : BaseCommand
     {
-        // bool used by vibrateWithPattern to stop when Cancel is pressed
-        private bool cancelPattern = false;
+        // bool used to determine if cancel was called during vibrateWithPattern
+        private bool cancelWasCalled = false;
 
         public void vibrate(string vibrateDuration)
         {
@@ -63,13 +63,19 @@ namespace WPCordovaClassLib.Cordova.Commands
 
         public async Task vibrateWithPattern(string options)
         {
+            // clear the cancelWasCalled flag
+            cancelWasCalled = false;
             // get options
             string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
-            long[] pattern = JSON.JsonHelper.Deserialize<long[]>(args[0]);
+            int[] pattern = JSON.JsonHelper.Deserialize<int[]>(args[0]);
 
-            for (int i = 0; i < pattern.Length && !cancelPattern; i++)
+            for (int i = 0; i < pattern.Length && !cancelWasCalled; i++)
             {
-                long msecs = pattern[i];
+                int msecs = pattern[i];
+                if (msecs < 1)
+                {
+                    msecs = 1;
+                }
                 if (i % 2 == 0)
                 {
                     msecs = (msecs > 5000) ? 5000 : msecs;
@@ -77,14 +83,13 @@ namespace WPCordovaClassLib.Cordova.Commands
                 }
                 await Task.Delay(TimeSpan.FromMilliseconds(msecs));
             }
-            cancelPattern = false;
             DispatchCommandResult();
         }
 
         public void cancelVibration(string options)
         {
             VibrateController.Default.Stop();
-            cancelPattern = true;
+            cancelWasCalled = true;
             DispatchCommandResult();
         }
     }

--- a/src/wp/Vibration.cs
+++ b/src/wp/Vibration.cs
@@ -45,6 +45,10 @@ namespace WPCordovaClassLib.Cordova.Commands
                 {
                     msecs = 1;
                 }
+                else if (msecs > 5000)
+                {
+                    msecs = 5000;
+                }
             }
             catch (FormatException)
             {
@@ -68,6 +72,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 long msecs = pattern[i];
                 if (i % 2 == 0)
                 {
+                    msecs = (msecs > 5000) ? 5000 : msecs;
                     VibrateController.Default.Start(TimeSpan.FromMilliseconds(msecs));
                 }
                 await Task.Delay(TimeSpan.FromMilliseconds(msecs));

--- a/src/wp/Vibration.cs
+++ b/src/wp/Vibration.cs
@@ -21,12 +21,15 @@ using System.Threading;
 using System.Windows.Resources;
 using Microsoft.Phone.Controls;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 
 namespace WPCordovaClassLib.Cordova.Commands
 {
     public class Vibration : BaseCommand
     {
+        // bool used by vibrateWithPattern to stop when Cancel is pressed
+        private bool cancelPattern = false;
 
         public void vibrate(string vibrateDuration)
         {
@@ -54,9 +57,29 @@ namespace WPCordovaClassLib.Cordova.Commands
             DispatchCommandResult();
         }
 
+        public async Task vibrateWithPattern(string options)
+        {
+            // get options
+            string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
+            long[] pattern = JSON.JsonHelper.Deserialize<long[]>(args[0]);
+
+            for (int i = 0; i < pattern.Length && !cancelPattern; i++)
+            {
+                long msecs = pattern[i];
+                if (i % 2 == 0)
+                {
+                    VibrateController.Default.Start(TimeSpan.FromMilliseconds(msecs));
+                }
+                await Task.Delay(TimeSpan.FromMilliseconds(msecs));
+            }
+            cancelPattern = false;
+            DispatchCommandResult();
+        }
+
         public void cancelVibration(string options)
         {
             VibrateController.Default.Stop();
+            cancelPattern = true;
             DispatchCommandResult();
         }
     }


### PR DESCRIPTION
Added support for:
    - cancelVibration (including vibration with pattern)
    - vibrateWithPattern
    - truncation of vibration when argument is > 5seconds on wp (formerly exception was thrown)