### PR TITLE
CB-8930: Vibration on Windows fails without a helpful error message when

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -76,7 +76,7 @@
         </js-module>
 
         <framework src="src/windows/Vibration/Vibration.csproj" target="phone"
-            type="projectReference" custom="true" />
+            type="projectReference" custom="true" versions="<10.0.0" />
     </platform>
 
     <!-- android -->


### PR DESCRIPTION
vibration functionality is missing from the platform.  This detects such a
case and instead fails gracefully that the feature isn't available.  Also
supports the Windows 10 vibration mechanism.