### PR TITLE
CB-9166: Changed plugin.xml framework reference condition to be valid XML

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -76,7 +76,7 @@
         </js-module>
 
         <framework src="src/windows/Vibration/Vibration.csproj" target="phone"
-            type="projectReference" custom="true" versions="<10.0.0" />
+            type="projectReference" custom="true" versions="&lt;10.0.0" />
     </platform>
 
     <!-- android -->


### PR DESCRIPTION
The original plugin.xml referenced "<10.0.0" which caused some validating XML readers to reject it as invalid.  Changed to entity-encoding.