### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ navigator.notification.cancelVibration
 
 This function has three different functionalities based on parameters passed to it.
 
-###Standard vibrate
+### Standard vibrate
 
 Vibrates the device for a given amount of time.
 
@@ -82,7 +82,7 @@ or
 
 -__time__: Milliseconds to vibrate the device. _(Number)_
 
-####Example
+#### Example
 
     // Vibrate for 3 seconds
     navigator.vibrate(3000);
@@ -90,26 +90,26 @@ or
     // Vibrate for 3 seconds
     navigator.vibrate([3000]);
 
-####iOS Quirks
+#### iOS Quirks
 
 - __time__: Ignores the specified time and vibrates for a pre-set amount of time.
 
     navigator.vibrate(3000); // 3000 is ignored
 
-####Windows and Blackberry Quirks
+#### Windows and Blackberry Quirks
 
 - __time__: Max time is 5000ms (5s) and min time is 1ms
 
     navigator.vibrate(8000); // will be truncated to 5000
 
-###Vibrate with a pattern (Android and Windows only)
+### Vibrate with a pattern (Android and Windows only)
 Vibrates the device with a given pattern
 
     navigator.vibrate(pattern);
 
 - __pattern__: Sequence of durations (in milliseconds) for which to turn on or off the vibrator. _(Array of Numbers)_
 
-####Example
+#### Example
 
     // Vibrate for 1 second
     // Wait for 1 second
@@ -118,11 +118,11 @@ Vibrates the device with a given pattern
     // Vibrate for 5 seconds
     navigator.vibrate([1000, 1000, 3000, 1000, 5000]);
 
-####Windows Phone 8 Quirks
+#### Windows Phone 8 Quirks
 
 - vibrate(pattern) falls back on vibrate with default duration
 
-###Cancel vibration (not supported in iOS)
+### Cancel vibration (not supported in iOS)
 
 Immediately cancels any currently running vibration.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
