### PR TITLE
CB-12695: fix jshint / double-varing

### DIFF
--- a/www/vibration.js
+++ b/www/vibration.js
@@ -108,7 +108,7 @@ module.exports = {
      */
     vibrateWithPattern: function(pattern, repeat) {
         repeat = (typeof repeat !== "undefined") ? repeat : -1;
-        var pattern = pattern.unshift(0); //add a 0 at beginning for backwards compatibility from w3c spec
+        pattern = pattern.unshift(0); //add a 0 at beginning for backwards compatibility from w3c spec
         exec(null, null, "Vibration", "vibrateWithPattern", [pattern, repeat]);
     },
 


### PR DESCRIPTION
### Platforms affected

All - JS

### What does this PR do?

Fixes `npm test` failure due to double-definition of `pattern` variable.

### What testing has been done on this change?

Just `npm test`. Ideally should wait for the CI qa-bot to respond before merging.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database: [CB-12695](https://issues.apache.org/jira/browse/CB-12695)
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
