### PR TITLE
CB-13672 : Remove multiple inclusion of js-module

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,11 +30,6 @@
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-vibration.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320639</issue>
 
-    <js-module src="www/vibration.js" name="notification">
-        <merges target="navigator.notification" />
-        <merges target="navigator" />
-    </js-module>
-
     <!-- firefoxos -->
     <platform name="firefoxos">
         <config-file target="www/config.xml" parent="/*">


### PR DESCRIPTION
Removed the multiple inclusion of js-module


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.

