### PR TITLE
ci(ios): update workflow w/ iOS 15

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   test:
     name: iOS ${{ matrix.versions.ios-version }} Test
-    runs-on: macos-latest
+    runs-on: ${{ matrix.versions.os-version }}
 
     # hoist configurations to top that are expected to be updated
     env:
@@ -49,9 +49,21 @@ jobs:
     strategy:
       matrix:
         versions:
-          - ios-version: 12.x
-          - ios-version: 13.x
-          - ios-version: 14.x
+          - os-version: macos-10.15
+            ios-version: 12.x
+            xcode-version: 11.x
+
+          - os-version: macos-10.15
+            ios-version: 13.x
+            xcode-version: 11.x
+
+          - os-version: macos-10.15
+            ios-version: 14.x
+            xcode-version: 12.x
+
+          - os-version: macos-11
+            ios-version: 15.x
+            xcode-version: 13.x
 
     steps:
       - uses: actions/checkout@v2
@@ -74,6 +86,12 @@ jobs:
         run: |
           npm i -g cordova@latest ios-deploy@latest
           npm ci
+
+      - name: Run setup iOS 12.x support
+        if: ${{ matrix.versions.ios-version == '12.x' }}
+        run: |
+          sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
+          sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
 
       - name: Run paramedic install
         if: ${{ endswith(env.repo, '/cordova-paramedic')　!= true }}


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation, Context & Description

Previously all iOS test appeared to run only on iOS 14.4.

This PR:

* Update GitHub Actions workflow to ensure that each defined iOS version was being tested correctly.
* Included iOS 15.x to the workflow.

### Testing

- CI

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
